### PR TITLE
Create yaml configs for Finland, Philippines, Our World in Data

### DIFF
--- a/src/config/sources/finland_hospitalizations.yaml
+++ b/src/config/sources/finland_hospitalizations.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+attribution:
+  country: 'Finland'
+  source_name: 'Finnish institute for health and welfare'
+  main_link: 'https://thl.fi/en/web/thlfi-en'
+  data_link: 'https://thl.fi/en/web/infectious-diseases/what-s-new/coronavirus-covid-19-latest-updates'
+  description: 'Data is scraped manually from the situation reports provided at the source link. Data for Finland consists of time series data for current ICU cases and hospitalizations.'
+license:
+  name: 'Creative Commons Attribution 4.0 International'
+  file: 'docs/license_files/cc-by-4.0'
+  link: 'https://creativecommons.org/licenses/by/4.0/'
+cc-by-sa: False
+approved: True

--- a/src/config/sources/our_world_data.yaml
+++ b/src/config/sources/our_world_data.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+attribution:
+  country: 'Our World in Data'
+  source_name: 'Our World in Data'
+  main_link: 'www.OurWorldInData.org'
+  data_link: 'https://ourworldindata.org/coronavirus'
+  description: 'Data from Our World in Data includes Deaths, Testing, Cases, and Government responses for every country in the world.'
+license:
+  name: 'Creative Commons Attribution 4.0 International'
+  file: 'docs/license_files/cc-by-4.0'
+  link: 'https://creativecommons.org/licenses/by/4.0/'
+cc-by-sa: False
+approved: True

--- a/src/config/sources/philippines_hospitalizations.yaml
+++ b/src/config/sources/philippines_hospitalizations.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+attribution:
+  country: 'Philippines'
+  source_name: 'Philippines Department of Health'
+  main_link: 'https://www.doh.gov.ph/'
+  data_link: 'http://www.doh.gov.ph/covid19tracker'
+  description: 'Data is downloaded manually from the source link. Data for Iceland consists of time series data for current ICU cases, and current and cumulative hospitalizations.'
+cc-by-sa: False
+approved: True
+# The Philippines data does not have a license, rather we've received written consent from the their Department of Health.


### PR DESCRIPTION
This pull request adds yaml files containing just the attribution/licensing sections for three new data sources (Finland hospitalization data, Philippines hospitalization data, and Our World in Data).

Subsequent pull requests will complete the yaml files and ingest the data into the pipeline.