### PR TITLE
Improve fetch_automatic_downloads and aggregated licenses

### DIFF
--- a/data/exports/cc_by/LICENSE
+++ b/data/exports/cc_by/LICENSE
@@ -9,7 +9,6 @@ Description: Data is scraped manually from the charts provided at the source lin
 Australia consists of time series data for current hospitalizations, ICU and ventilator cases.
 License: Creative Commons Attribution 4.0 International
 (https://creativecommons.org/licenses/by/4.0/)
-Last accessed: 2020-06-28
 
 COVIDTracking
 Source name: COVID-19 Tracking Project (https://github.com/COVID19Tracking/)
@@ -17,7 +16,6 @@ Link to data: https://github.com/COVID19Tracking/covid-tracking-data/tree/master
 Description: Data is downloaded automatically from the source link. Data for the United States
 consists of time series data for current and cumulative hospitalizations.
 License: Apache 2.0 (https://github.com/COVID19Tracking/covid-tracking-data/blob/master/LICENSE)
-Last accessed: 2020-06-29
 
 Czech Republic
 Source name: National Health Information System, Regional Hygiene Stations, Ministry of Health of
@@ -34,14 +32,12 @@ Přehled aktuální situace v ČR. Onemocnění aktuálně [online]. Praha: Mini
 2020 [cit. 25.04.2020]. Dostupné z: https://onemocneni-aktualne.mzcr.cz/covid-19. Vývoj: společné
 pracoviště ÚZIS ČR a IBA LF MU. ISSN 2694-9423.
 ```
-Last accessed: 2020-06-28
 
 Denmark
 Source name: Statens Serum Institute (https://www.sst.dk/)
 Link to data: https://www.sst.dk/da/corona/tal-og-overvaagning
 Description: Data is manually scraped from charts at the source link. Data for Denmark consists of
 time series data for current hospitalizations and ICU cases.
-Last accessed: 2020-06-28
 
 France
 Source name: data.gouv.fr (https://www.data.gouv.fr/)
@@ -50,14 +46,12 @@ https://www.data.gouv.fr/en/datasets/donnees-hospitalieres-relatives-a-lepidemie
 Description: Data is scraped manually from the charts provided at the source link. Data for France
 consists of time series data for cumulative hospitalizations and ICU cases.
 License: Open License 2.0 (https://www.etalab.gouv.fr/licence-ouverte-open-licence)
-Last accessed: 2020-06-29
 
 Iceland
 Source name: Directorate of Health in Iceland (Embaetti landlaeknis) (https://www.covid.is/data)
 Link to data: https://www.covid.is/data
 Description: Data is downloaded manually from the source link. Data for Iceland consists of time
 series data for current ICU cases, and current and cumulative hospitalizations.
-Last accessed: 2020-06-22
 
 Italy
 Source name: Dipartimento della Protezione Civile
@@ -67,7 +61,6 @@ Description: Data is downloaded automatically from the source repository. Data f
 time series data for current hospitalizations, but we can also compute cumulative hospitalizations.
 License: Creative Commons Attribution 4.0 International
 (https://creativecommons.org/licenses/by/4.0/)
-Last accessed: 2020-06-29
 
 Japan
 Source name: Toyo Keizai Online (https://github.com/kaz-ogiwara/covid19)
@@ -76,7 +69,6 @@ Copyright notice: Copyright (c) 2020 Kazuki OGIWARA / 荻原 和樹
 Description: Data is downloaded automatically from the source repository. Data for Japan consists of
 time series data for current hospitalizations and ICU cases.
 License: MIT (https://github.com/kaz-ogiwara/covid19/blob/master/LICENSE)
-Last accessed: 2020-06-29
 
 Luxembourg
 Source name: Luxembourg Ministry of Health (https://data.public.lu/fr/datasets/donnees-covid19/#_)
@@ -85,7 +77,6 @@ Description: Data is downloaded automatically from the source link. Data for Lux
 time series data for current hospitalizations and ICU cases.
 License: Creative Commons Zero 1.0 Universal
 (https://creativecommons.org/share-your-work/public-domain/cc0/)
-Last accessed: 2020-06-29
 
 Netherlands
 Source name: National Institute for Public Health and The Environment
@@ -93,13 +84,11 @@ Source name: National Institute for Public Health and The Environment
 Link to data: https://www.rivm.nl/coronavirus-covid-19/grafieken
 Description: Data is downloaded manually from the source link. Data for the Netherlands consists of
 time series data for current hospitalizations.
-Last accessed: 2020-06-29
 
 Norway
 Source name: Norwegian Institute of Public Health (www.fhi.no)
 Link to data:
 https://www.fhi.no/en/id/infectious-diseases/coronavirus/daily-reports/daily-reports-COVID19/
-Last accessed: 2020-06-22
 
 Our World in Data
 Source name: Our World in Data (www.OurWorldInData.org)
@@ -112,7 +101,6 @@ Data from Our World in Data has been collected, aggregated, and documented by Di
 Daniel Gavrilov, Charlie Giattino, Joe Hasell, Bobbie Macdonald, Edouard Mathieu, Esteban
 Ortiz-Ospina, Hannah Ritchie, and Max Roser.
 ```
-Last accessed: 2020-06-29
 
 Oxford Covid-19 Government Response Tracker
 Source name: Oxford Covid-19 Government Response Tracker
@@ -125,7 +113,6 @@ Citation:
 Thomas Hale, Sam Webster, Anna Petherick, Toby Phillips, and Beatriz Kira. (2020). Oxford COVID-19
 Government Response Tracker. Blavatnik School of Government.
 ```
-Last accessed: 2020-06-29
 
 Spain
 Source name: Ministerio de Sanidad, Consumo y Bienestar Social
@@ -134,7 +121,6 @@ Link to data: https://cnecovid.isciii.es/covid19/resources/agregados.csv
 Description: The data is downloaded automatically from the source link. Due to regional differences
 in hospitalization reporting, we do not aggregate across regions to produce country-level statistics
 for Spain.
-Last accessed: 2020-06-29
 
 Sweden
 Source name: Public Health Agency of Sweden
@@ -143,14 +129,12 @@ Link to data:
 https://www.arcgis.com/sharing/rest/content/items/b5e7488e117749c19881cce45db13f7e/data
 Description: Data is downloaded automatically from the source link. Data for Sweden consists of time
 series data for current ICU cases.
-Last accessed: 2020-06-29
 
 Switzerland
 Source name: Switzerland Federal Office of Public Health BAG
 (https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/situation-schweiz-und-international.html)
 Link to data:
 https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/situation-schweiz-und-international.html
-Last accessed: 2020-06-29
 
 United Kingdom
 Source name: GOV.UK (https://www.gov.uk)
@@ -160,7 +144,6 @@ aggregated across regions in England and reported at the country level for Engla
 and Northern Ireland. Data consists of time series data for current hospitalizations.
 License: Open Government License 3.0
 (http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/)
-Last accessed: 2020-06-23
 
 =======================================================================
 Complete license texts for each unique license are available below:

--- a/data/exports/cc_by_sa/LICENSE
+++ b/data/exports/cc_by_sa/LICENSE
@@ -9,7 +9,6 @@ Description: Data is scraped manually from the charts provided at the source lin
 Australia consists of time series data for current hospitalizations, ICU and ventilator cases.
 License: Creative Commons Attribution 4.0 International
 (https://creativecommons.org/licenses/by/4.0/)
-Last accessed: 2020-06-28
 
 COVIDTracking
 Source name: COVID-19 Tracking Project (https://github.com/COVID19Tracking/)
@@ -17,7 +16,6 @@ Link to data: https://github.com/COVID19Tracking/covid-tracking-data/tree/master
 Description: Data is downloaded automatically from the source link. Data for the United States
 consists of time series data for current and cumulative hospitalizations.
 License: Apache 2.0 (https://github.com/COVID19Tracking/covid-tracking-data/blob/master/LICENSE)
-Last accessed: 2020-06-29
 
 Colombia
 Original data source: GOV.CO (https://www.datos.gov.co)
@@ -29,7 +27,6 @@ from datos.gov.co. Data for Colombia consists of time series data for current ho
 ICU cases.
 License: Creative Commons Attribution-ShareAlike 4.0 International
 (https://creativecommons.org/licenses/by-sa/4.0/)
-Last accessed: 2020-06-29
 
 Czech Republic
 Source name: National Health Information System, Regional Hygiene Stations, Ministry of Health of
@@ -46,14 +43,12 @@ Přehled aktuální situace v ČR. Onemocnění aktuálně [online]. Praha: Mini
 2020 [cit. 25.04.2020]. Dostupné z: https://onemocneni-aktualne.mzcr.cz/covid-19. Vývoj: společné
 pracoviště ÚZIS ČR a IBA LF MU. ISSN 2694-9423.
 ```
-Last accessed: 2020-06-28
 
 Denmark
 Source name: Statens Serum Institute (https://www.sst.dk/)
 Link to data: https://www.sst.dk/da/corona/tal-og-overvaagning
 Description: Data is manually scraped from charts at the source link. Data for Denmark consists of
 time series data for current hospitalizations and ICU cases.
-Last accessed: 2020-06-28
 
 France
 Source name: data.gouv.fr (https://www.data.gouv.fr/)
@@ -62,14 +57,12 @@ https://www.data.gouv.fr/en/datasets/donnees-hospitalieres-relatives-a-lepidemie
 Description: Data is scraped manually from the charts provided at the source link. Data for France
 consists of time series data for cumulative hospitalizations and ICU cases.
 License: Open License 2.0 (https://www.etalab.gouv.fr/licence-ouverte-open-licence)
-Last accessed: 2020-06-29
 
 Iceland
 Source name: Directorate of Health in Iceland (Embaetti landlaeknis) (https://www.covid.is/data)
 Link to data: https://www.covid.is/data
 Description: Data is downloaded manually from the source link. Data for Iceland consists of time
 series data for current ICU cases, and current and cumulative hospitalizations.
-Last accessed: 2020-06-22
 
 Ireland
 Source name: Health Protection Surveillance Centre (https://www.hpsc.ie/)
@@ -79,7 +72,6 @@ Description: Data is scraped manually from daily situation reports. Data for Ire
 time series data for cumulative hospitalizations.
 License: Creative Commons Attribution ShareAlike 3.0
 (https://creativecommons.org/licenses/by-sa/3.0/)
-Last accessed: 2020-06-02
 
 Italy
 Source name: Dipartimento della Protezione Civile
@@ -89,7 +81,6 @@ Description: Data is downloaded automatically from the source repository. Data f
 time series data for current hospitalizations, but we can also compute cumulative hospitalizations.
 License: Creative Commons Attribution 4.0 International
 (https://creativecommons.org/licenses/by/4.0/)
-Last accessed: 2020-06-29
 
 Japan
 Source name: Toyo Keizai Online (https://github.com/kaz-ogiwara/covid19)
@@ -98,7 +89,6 @@ Copyright notice: Copyright (c) 2020 Kazuki OGIWARA / 荻原 和樹
 Description: Data is downloaded automatically from the source repository. Data for Japan consists of
 time series data for current hospitalizations and ICU cases.
 License: MIT (https://github.com/kaz-ogiwara/covid19/blob/master/LICENSE)
-Last accessed: 2020-06-29
 
 Luxembourg
 Source name: Luxembourg Ministry of Health (https://data.public.lu/fr/datasets/donnees-covid19/#_)
@@ -107,7 +97,6 @@ Description: Data is downloaded automatically from the source link. Data for Lux
 time series data for current hospitalizations and ICU cases.
 License: Creative Commons Zero 1.0 Universal
 (https://creativecommons.org/share-your-work/public-domain/cc0/)
-Last accessed: 2020-06-29
 
 Netherlands
 Source name: National Institute for Public Health and The Environment
@@ -115,13 +104,11 @@ Source name: National Institute for Public Health and The Environment
 Link to data: https://www.rivm.nl/coronavirus-covid-19/grafieken
 Description: Data is downloaded manually from the source link. Data for the Netherlands consists of
 time series data for current hospitalizations.
-Last accessed: 2020-06-29
 
 Norway
 Source name: Norwegian Institute of Public Health (www.fhi.no)
 Link to data:
 https://www.fhi.no/en/id/infectious-diseases/coronavirus/daily-reports/daily-reports-COVID19/
-Last accessed: 2020-06-22
 
 Our World in Data
 Source name: Our World in Data (www.OurWorldInData.org)
@@ -134,7 +121,6 @@ Data from Our World in Data has been collected, aggregated, and documented by Di
 Daniel Gavrilov, Charlie Giattino, Joe Hasell, Bobbie Macdonald, Edouard Mathieu, Esteban
 Ortiz-Ospina, Hannah Ritchie, and Max Roser.
 ```
-Last accessed: 2020-06-29
 
 Oxford Covid-19 Government Response Tracker
 Source name: Oxford Covid-19 Government Response Tracker
@@ -147,7 +133,6 @@ Citation:
 Thomas Hale, Sam Webster, Anna Petherick, Toby Phillips, and Beatriz Kira. (2020). Oxford COVID-19
 Government Response Tracker. Blavatnik School of Government.
 ```
-Last accessed: 2020-06-29
 
 Spain
 Source name: Ministerio de Sanidad, Consumo y Bienestar Social
@@ -156,7 +141,6 @@ Link to data: https://cnecovid.isciii.es/covid19/resources/agregados.csv
 Description: The data is downloaded automatically from the source link. Due to regional differences
 in hospitalization reporting, we do not aggregate across regions to produce country-level statistics
 for Spain.
-Last accessed: 2020-06-29
 
 Sweden
 Source name: Public Health Agency of Sweden
@@ -165,14 +149,12 @@ Link to data:
 https://www.arcgis.com/sharing/rest/content/items/b5e7488e117749c19881cce45db13f7e/data
 Description: Data is downloaded automatically from the source link. Data for Sweden consists of time
 series data for current ICU cases.
-Last accessed: 2020-06-29
 
 Switzerland
 Source name: Switzerland Federal Office of Public Health BAG
 (https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/situation-schweiz-und-international.html)
 Link to data:
 https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/situation-schweiz-und-international.html
-Last accessed: 2020-06-29
 
 United Kingdom
 Source name: GOV.UK (https://www.gov.uk)
@@ -182,7 +164,6 @@ aggregated across regions in England and reported at the country level for Engla
 and Northern Ireland. Data consists of time series data for current hospitalizations.
 License: Open Government License 3.0
 (http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/)
-Last accessed: 2020-06-23
 
 =======================================================================
 Complete license texts for each unique license are available below:

--- a/src/pipeline/license_utils.py
+++ b/src/pipeline/license_utils.py
@@ -56,8 +56,9 @@ def export_aggregated_license(export_path, sources_path, license_files, header):
     with open(export_path, 'w') as outfile:
         outfile.write(header)
         for line in text_output(sources_path):
-            outfile.write(line)
-            outfile.write('\n')
+            if 'Last accessed:' not in line:
+                outfile.write(line)
+                outfile.write('\n')
         outfile.write('=======================================================================\n')
         outfile.write(complete_texts)
         for fname in license_files:

--- a/src/scripts/fetch_automatic_downloads.py
+++ b/src/scripts/fetch_automatic_downloads.py
@@ -41,22 +41,23 @@ if not args.whitelist:
 
 automatic_downloads = config.read_config(cc_by=True, cc_by_sa=True, google_tos=True,
                                          filter_by_fetch_method='AUTOMATIC_DOWNLOAD',
-                                         filter_no_data=False, filter_not_approved=args.whitelist)
+                                         filter_no_load_func=False,
+                                         filter_no_data=False,
+                                         filter_not_approved=args.whitelist)
 todays_date = datetime.today().strftime('%Y-%m-%d')
 
 for k in automatic_downloads:
     params = automatic_downloads[k]
     source_url = params['fetch']['source_url']
-    if not path_utils.has_data_from_date(params, todays_date):
-        path_for_today = path_utils.path_to_data_for_date(params, todays_date)
-        print('Downloading data for: ', k)
-        print('Source url: ', source_url)
-        out_dir = path_for_today['dir']
-        out_file = path_for_today['file']
-        out_path = os.path.join(out_dir, out_file)
-        if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
-        output = wget.download(source_url, out_path)
-        print('\nFile written to: ', output)
+    path_for_today = path_utils.path_to_data_for_date(params, todays_date)
+    print('Downloading data for: ', k)
+    print('Source url: ', source_url)
+    out_dir = path_for_today['dir']
+    out_file = path_for_today['file']
+    out_path = os.path.join(out_dir, out_file)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    output = wget.download(source_url, out_path)
+    print('\nFile written to: ', output)
 
 print('Done with fetch_automatic_downloads.py')


### PR DESCRIPTION
- [x] Instead of checking whether there is already data present for today, download the data anyways and overwrite today's subdir. (If the same data was already fetched, this will just not create any diff.)
- [x] Filter out the "Last accessed: " lines in the aggregated LICENSE files, so that the automatic data update workflows don't create a diff on the license files.