### PR TITLE
Check for duplicates in exported data

### DIFF
--- a/src/pipeline/load_functions.py
+++ b/src/pipeline/load_functions.py
@@ -17,6 +17,7 @@
 
 import pandas as pd
 import numpy as np
+import logging
 
 import region_utils
 import load_utils
@@ -26,6 +27,11 @@ import date_utils
 def default_load_function(data_path, params):
     df = load_utils.default_read_function(data_path, params)
     df = region_utils.join_region_codes(df, params)
+    duplicates = df[df[['region_code', 'date']].duplicated(keep=False)]
+    if duplicates.shape[0] != 0:
+        logging.warning('Dropping the following duplicate data for %s data source:\n%s',
+                        params['config_key'], duplicates[['region_code', 'date']])
+        df = df.drop_duplicates(subset=['region_code', 'date'], keep='first')
     load_params = params['load']
     if 'regions' in load_params:
         if 'aggregate_by' in load_params['regions']:

--- a/tests/test_exported_data.py
+++ b/tests/test_exported_data.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pandas as pd
+import sys
+
+CURRENT_DIR = os.path.dirname(__file__)
+ROOT_DIR = os.path.abspath(os.path.join(CURRENT_DIR, '../'))
+PIPELINE_DIR = os.path.join(ROOT_DIR, 'src/pipeline')
+EXPORT_DIR = os.path.join(ROOT_DIR, 'data/exports')
+EXPORT_FILES = ['cc_by/aggregated_cc_by.csv',
+                'cc_by_sa/aggregated_cc_by_sa.csv',
+                'google_tos/aggregated_google_tos.csv']
+
+sys.path.append(PIPELINE_DIR)
+
+def test_location_and_date_unique():
+    for f in EXPORT_FILES:
+        export_path = os.path.join(EXPORT_DIR, f)
+        exported_df = pd.read_csv(export_path)
+        duplicates = exported_df[exported_df[['region_code', 'date']].duplicated(keep=False)]
+        duplicate_info = duplicates[['region_code', 'date']]
+        print(duplicate_info)
+        assert duplicates.shape[0] == 0


### PR DESCRIPTION
- [x] Add a unit test that checks that exported data is unique for `region_code, date` pairs.
- [x] Manually check existing duplicates to verify they are present in input data and not being introduced in the pipeline.
- [x] Add a step in default load function that dedupes and logs which data is being dropped.