### PR TITLE
Update mobility and japan configs

### DIFF
--- a/src/config/sources/google_mobility_reports.yaml
+++ b/src/config/sources/google_mobility_reports.yaml
@@ -14,9 +14,10 @@
 
 ---
 fetch:
-  method: 'AUTOMATIC_DOWNLOAD'
+  method: 'MANUAL_DOWNLOAD'
   source_url: 'https://www.gstatic.com/covid19/mobility/Global_Mobility_Report.csv'
   file: 'Global_Mobility_Report.csv'
+  instructions: 'Data exceeds 100MB limit per file, need to split data into smaller files.'
 load:
   function: 'mobility_load_function'
   dates:

--- a/src/config/sources/japan_hospitalizations.yaml
+++ b/src/config/sources/japan_hospitalizations.yaml
@@ -15,8 +15,9 @@
 ---
 fetch:
   source_url: 'https://raw.githubusercontent.com/kaz-ogiwara/covid19/master/data/summary.csv'
-  method: 'AUTOMATIC_DOWNLOAD'
+  method: 'MANUAL_DOWNLOAD'
   file: 'summary.csv'
+  instructions: 'File structure has changed, need to locate new csv with hospitalization data.'
 load:
   function: 'default_load_function'
   dates:


### PR DESCRIPTION
Set google_mobility_reports and japan_hospitalizations to be manual downloads, so that the data update workflow can run successfully.